### PR TITLE
adds release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,222 @@
+name: release
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      devN:
+        description: 'development release number'
+        required: false
+        default: '0'
+
+jobs:
+
+  checks:
+    name: check releases
+    if: github.ref == 'refs/heads/stable'
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.current_version.outputs.current_version }}
+      release_info: ${{ steps.release_info.outputs.release_info }}
+      asset_tgz_url: ${{ steps.release_info.outputs.asset_tgz_url }}
+      asset_whl_url: ${{ steps.release_info.outputs.asset_whl_url }}
+      upload_url:  ${{ steps.release_info.outputs.upload_url }}
+      already_in_pypi: ${{ steps.check_in_pypi.outputs.pypi_versions != '' }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Get current version
+        id: current_version
+        run: |
+          python -m pip install . --no-deps
+          out="$(pip show ${{ env.PKG_NAME }} | grep Version: | cut -d'' '' -f 2)"
+          echo "$out"
+          echo "::set-output name=current_version::$out"
+        shell: bash
+
+      - name: Get release info
+        id: release_info
+        run: |
+          release_info="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+              | jq '.[] | select(.name == "v${{ steps.current_version.outputs.current_version }}")')"
+          echo "::set-output name=release_info::$release_info"
+          echo "$release_info"
+
+          asset_tgz_url="$(echo "$release_info" \
+              | jq -r '.assets[] | select(.name | match("^${{ env.PKG_NAME }}.*\\.tar.gz$")) | .browser_download_url')"
+          echo "::set-output name=asset_tgz_url::$asset_tgz_url"
+          echo "$asset_tgz_url"
+
+          asset_whl_url="$(echo "$release_info" \
+              | jq -r '.assets[] | select(.name | match("^${{ env.PKG_NAME }}.*\\.whl$")) | .browser_download_url')"
+          echo "::set-output name=asset_whl_url::$asset_whl_url"
+          echo "$asset_whl_url"
+
+          upload_url="$(echo "$release_info" | jq -r '.upload_url')"
+          echo "::set-output name=upload_url::$upload_url"
+          echo "$upload_url"
+        shell: bash
+
+      - name: check if already deployed to PyPI
+        id: check_in_pypi
+        # Note. other options:
+        #   - use 'pip install --no-deps PKG==VERSION' with current version
+        #   - use 'pip index versions PKG==VERSION'
+        #     (but it's a kind of experimental feature of pip >= 21.2)
+        run: |
+          python -m pip install --upgrade pip
+          out="$(pip install --use-deprecated=legacy-resolver ${{ env.PKG_NAME }}== 2>&1 \
+              | grep -E "Could not find .* ${{ steps.current_version.outputs.current_version }}(,|\))")"
+          echo "::set-output name=pypi_versions::$out"
+        shell: bash {0}  # to opt-out of default fail-fast behavior
+
+  release-github:
+    name: GitHub Release
+    if: github.ref == 'refs/heads/stable'
+    runs-on: ubuntu-latest
+    needs: checks
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: build dist
+        id: build_assets
+        if: ${{ !(needs.checks.outputs.asset_tgz_url && needs.checks.outputs.asset_whl_url) }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m build
+          ls dist
+
+          asset_tgz_name="$(find dist -name '*.tar.gz' -printf '%f')"
+          echo "::set-output name=asset_tgz_name::$asset_tgz_name"
+
+          asset_whl_name="$(find dist -name '*.whl' -printf '%f')"
+          echo "::set-output name=asset_whl_name::$asset_whl_name"
+        shell: bash
+
+      - name: Create Release
+        id: create_release
+        if: ${{ ! needs.checks.outputs.release_info }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ needs.checks.outputs.current_version }}
+          release_name: v${{ needs.checks.outputs.current_version }}
+
+      - name: Set upload url
+        id: upload_url
+        if: ${{ !(needs.checks.outputs.asset_tgz_url && needs.checks.outputs.asset_whl_url) }}
+        run: |
+          if [[ -n "${{ needs.checks.outputs.upload_url }}" ]]; then
+            echo "::set-output name=value::${{ needs.checks.outputs.upload_url }}"
+          else
+            echo "::set-output name=value::${{ steps.create_release.outputs.upload_url }}"
+          fi
+
+      - name: Upload the source archive
+        if: ${{ !needs.checks.outputs.asset_tgz_url }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.upload_url.outputs.value }}
+          asset_path: dist/${{ steps.build_assets.outputs.asset_tgz_name }}
+          asset_name: ${{ steps.build_assets.outputs.asset_tgz_name }}
+          asset_content_type: application/x-gtar
+
+      - name: Upload the wheel
+        if: ${{ !needs.checks.outputs.asset_whl_url }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.upload_url.outputs.value }}
+          asset_path: dist/${{ steps.build_assets.outputs.asset_whl_name }}
+          asset_name: ${{ steps.build_assets.outputs.asset_whl_name }}
+          asset_content_type: application/zip
+
+  deploy-pypi:
+    name: Deploy to PyPI
+    if: github.ref == 'refs/heads/stable' && needs.checks.outputs.already_in_pypi == 'false'
+    runs-on: ubuntu-latest
+    needs: [checks, release-github]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: download GitHub artifacts
+        run: |
+          mkdir -p dist
+          cd dist
+          curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ needs.checks.outputs.current_version }} \
+            | jq -r ".assets[] | select(.name | contains(\"${{ env.PKG_NAME }}\")) | .browser_download_url" \
+            | wget -i -
+          ls
+        shell: bash
+
+      # NOTE uncomment once community actions are allowed for the github org
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@v1.4.2
+      #   with:
+      #       user: __token__
+      #       password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Prepare python env
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade twine
+        shell: bash
+
+      - name: Publish to PyPI
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive --username __token__ dist/*
+        shell: bash
+
+  deploy-test-pypi:
+    name: Deploy to TestPyPI
+    if: github.ref != 'refs/heads/stable' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: set dev version
+        run: |
+          sed -i -r "s~version=\"(.+)\"~version=\"\1.dev${{ github.event.inputs.devN }}\"~" ./setup.py
+          grep version ./setup.py
+        shell: bash
+
+      - name: build dist
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m build
+          ls dist
+        shell: bash
+
+      - name: install twine
+        run: python -m pip install --upgrade twine
+        shell: bash
+
+      - name: Publish to TestPyPI
+        env:
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive --username __token__ --repository testpypi dist/*
+        shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,50 @@ name: tests
 
 on: [ pull_request ]
 
-jobs:
-  build:
 
+env:
+  PKG_NAME: didcomm
+
+
+jobs:
+
+  check-version-bumped:
+    name: Check version bumped
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'stable'
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Get current version
+        id: current_version
+        run: |
+          python -m pip install --upgrade pip
+          pip install . --no-deps
+          out="$(pip show ${{ env.PKG_NAME }} | grep Version: | cut -d'' '' -f 2)"
+          echo "$out"
+          echo "::set-output name=current_version::$out"
+        shell: bash
+
+      # TODO improve (DRY): copy-paste from release.yml
+      - name: Get release info
+        id: release_info
+        run: |
+          release_info="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+              | jq '.[] | select(.name == "v${{ steps.current_version.outputs.current_version }}")')"
+          echo "::set-output name=release_info::$release_info"
+          echo "$release_info"
+        shell: bash
+
+      - name: fail unless release not found
+        # TODO check if greater than latest tag / release (?)
+        if: steps.release_info.outputs.release_info
+        run: exit 1
+
+  build:
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/sicpa-dlab/didcomm-python",
-    author="",
-    author_email="",
+    author="SICPA",
+    author_email="DLCHOpenSourceContrib@sicpa.com",
     license="Apache-2.0",
     python_requires=">=3.7",
     classifiers=[

--- a/tests/unit/didcomm/protocols/routing/test_forward_message.py
+++ b/tests/unit/didcomm/protocols/routing/test_forward_message.py
@@ -74,8 +74,12 @@ def _build_mturi(
         pytest.param(
             _build_mturi(prot="someprotocol"), DIDCommValueError, id="protocol"
         ),
-        pytest.param(_build_mturi(ver="3.0"), DIDCommValueError, id="too_old_version"),
-        pytest.param(_build_mturi(ver="1.9"), DIDCommValueError, id="too_new_version"),
+        pytest.param(
+            _build_mturi(ver="1.9"), DIDCommValueError, id="too_old_version_1.9"
+        ),
+        pytest.param(
+            _build_mturi(ver="3.0"), DIDCommValueError, id="too_new_version_3.0"
+        ),
         pytest.param(_build_mturi(msg_t="somemsg"), DIDCommValueError, id="message_t"),
     ],
 )


### PR DESCRIPTION
Implements logic of release flows as follows:

- PR to stable:
    - job: fail the pipeline unless the current version is different than the latest tag
        - _follow-up_: current version should be higher
- push to stable / manual re-run:
    - job: idempotence checks
        - GitHub latest release check: whether it is the same as the current version
        - whether PyPI release includes the current version
    - job: GitHub Release
        - if no release yet:
            - build locally
            - push with tag creation
    - job: PyPI release
        - if no PyPI release yet:
            - download distributive from GitHub releases
            - publish to PyPI
- manual run for non stable branches:
  - accepts input for dev release number
  - builds distributions
  - uploads to TestPyPI