### PR TITLE
Added support for more key formats for secrets

### DIFF
--- a/didcomm/core/utils.py
+++ b/didcomm/core/utils.py
@@ -117,13 +117,13 @@ def _extract_key_from_verifciation_method(
         else:
             raise DIDCommValueError()
 
-        codec, raw_value = from_multicodec(prefixed_raw_value)
+        codec, raw_value = _from_multicodec(prefixed_raw_value)
 
         expected_codec = (
-            Codec.X25519
+            _Codec.X25519_PUB
             if verification_method.type
             == VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020
-            else Codec.ED25519
+            else _Codec.ED25519_PUB
         )
 
         if codec != expected_codec:
@@ -149,6 +149,9 @@ def _extract_key_from_verifciation_method(
         raise DIDCommValueError()
 
 
+_CURVE25519_POINT_SIZE = 32
+
+
 def _extract_key_from_secret(secret: Secret, align_kid) -> AsymmetricKey:
     if secret.type == VerificationMethodType.JSON_WEB_KEY_2020:
         if secret.verification_material.format != VerificationMaterialFormat.JWK:
@@ -166,38 +169,136 @@ def _extract_key_from_secret(secret: Secret, align_kid) -> AsymmetricKey:
         else:
             raise DIDCommValueError()
 
+    elif secret.type in [
+        VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2019,
+        VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+    ]:
+        if secret.verification_material.format != VerificationMaterialFormat.BASE58:
+            raise DIDCommValueError()
+
+        raw_value = base58.b58decode(secret.verification_material.value)
+
+        raw_d_value = raw_value[:_CURVE25519_POINT_SIZE]
+        raw_x_value = raw_value[_CURVE25519_POINT_SIZE:]
+
+        base64url_d_value = urlsafe_b64encode(raw_d_value)
+        base64url_x_value = urlsafe_b64encode(raw_x_value)
+
+        jwk = {
+            "kty": "OKP",
+            "crv": "X25519"
+            if secret.type == VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2019
+            else "Ed25519",
+            "x": to_unicode(base64url_x_value),
+            "d": to_unicode(base64url_d_value),
+        }
+
+        if align_kid:
+            jwk["kid"] = secret.kid
+
+        return OKPKey.import_key(jwk)
+
+    elif secret.type in [
+        VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020,
+        VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+    ]:
+        if secret.verification_material.format != VerificationMaterialFormat.MULTIBASE:
+            raise DIDCommValueError()
+
+        # Currently only base58btc encoding is supported in scope of multibase support
+        if secret.verification_material.value.startswith("z"):
+            prefixed_raw_value = base58.b58decode(
+                secret.verification_material.value[1:]
+            )
+        else:
+            raise DIDCommValueError()
+
+        codec, raw_value = _from_multicodec(prefixed_raw_value)
+
+        expected_codec = (
+            _Codec.X25519_PRIV
+            if secret.type == VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020
+            else _Codec.ED25519_PRIV
+        )
+
+        if codec != expected_codec:
+            raise DIDCommValueError()
+
+        raw_d_value = raw_value[:_CURVE25519_POINT_SIZE]
+        raw_x_value = raw_value[_CURVE25519_POINT_SIZE:]
+
+        base64url_d_value = urlsafe_b64encode(raw_d_value)
+        base64url_x_value = urlsafe_b64encode(raw_x_value)
+
+        jwk = {
+            "kty": "OKP",
+            "crv": "X25519"
+            if secret.type == VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020
+            else "Ed25519",
+            "x": to_unicode(base64url_x_value),
+            "d": to_unicode(base64url_d_value),
+        }
+
+        if align_kid:
+            jwk["kid"] = secret.kid
+
+        return OKPKey.import_key(jwk)
+
     else:
         raise DIDCommValueError()
 
 
-def extract_sign_alg(verification_method: Union[VerificationMethod, Secret]) -> SignAlg:
-    if (
-        verification_method.type == VerificationMethodType.JSON_WEB_KEY_2020
-        and verification_method.verification_material.format
-        == VerificationMaterialFormat.JWK
-    ):
-        jwk = json_str_to_dict(verification_method.verification_material.value)
+class _Codec(Enum):
+    X25519_PUB = 0xEC
+    ED25519_PUB = 0xED
+    ED25519_PRIV = 0x1300
+    X25519_PRIV = 0x1302
+
+
+def _from_multicodec(value: bytes) -> (_Codec, bytes):
+    try:
+        prefix_int = varint.decode_bytes(value)
+    except Exception:
+        raise ValueError("Invalid multicodec prefix in {}".format(str(value)))
+
+    try:
+        codec = _Codec(prefix_int)
+    except ValueError:
+        raise ValueError(
+            "Unknown multicodec prefix {} in {}".format(str(prefix_int), str(value))
+        )
+
+    prefix = varint.encode(prefix_int)
+    return codec, value[len(prefix):]
+
+
+def extract_sign_alg(method: Union[VerificationMethod, Secret]) -> SignAlg:
+    if method.type == VerificationMethodType.JSON_WEB_KEY_2020:
+        if method.verification_material.format != VerificationMaterialFormat.JWK:
+            raise DIDCommValueError()
+
+        jwk = json_str_to_dict(method.verification_material.value)
+
         if jwk["kty"] == "EC" and jwk["crv"] == "P-256":
             return SignAlg.ES256
         elif jwk["kty"] == "EC" and jwk["crv"] == "secp256k1":
             return SignAlg.ES256K
         elif jwk["kty"] == "OKP" and jwk["crv"] == "Ed25519":
             return SignAlg.ED25519
+        else:
+            raise DIDCommValueError()
 
-        raise DIDCommValueError()
+    elif method.type in [
+        VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+        VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+    ]:
+        return SignAlg.ED25519
 
-    # elif verification_method.type == (
-    #     VerificationMethodType.ED25519_VERIFICATION_KEY_2018
-    # ):
-    #     return SignAlg.ED25519
-    #
-    # elif (
-    #     verification_method.type
-    #     == VerificationMethodType.ECDSA_SECP_256K1_VERIFICATION_KEY_2019
-    # ):
+    # elif method.type == VerificationMethodType.ECDSA_SECP_256K1_VERIFICATION_KEY_2019:
     #     return SignAlg.ES256K
 
-    raise DIDCommValueError()
+    else:
+        raise DIDCommValueError()
 
 
 # TODO TEST
@@ -297,25 +398,3 @@ def calculate_apv(kids: List[DID_URL]) -> str:
     return to_unicode(
         urlsafe_b64encode(hashlib.sha256(to_bytes(".".join(sorted(kids)))).digest())
     )
-
-
-class Codec(Enum):
-    X25519 = 0xEC
-    ED25519 = 0xED
-
-
-def from_multicodec(value: bytes) -> (Codec, bytes):
-    try:
-        prefix_int = varint.decode_bytes(value)
-    except TypeError:
-        raise ValueError("Invalid multicodec prefix in {}".format(str(value)))
-
-    try:
-        codec = Codec(prefix_int)
-    except ValueError:
-        raise ValueError(
-            "Unknown multicodec prefix {} in {}".format(str(prefix_int), str(value))
-        )
-
-    prefix = varint.encode(prefix_int)
-    return codec, value[len(prefix) :]

--- a/tests/unit/keys/test_extract_key.py
+++ b/tests/unit/keys/test_extract_key.py
@@ -42,6 +42,38 @@ def test_extract_okp_key_from_json_web_key_2020_verification_method():
     }
 
 
+def test_extract_okp_key_from_json_web_key_2020_secret():
+    key = extract_key(
+        Secret(
+            kid="did:example:alice#key-ed25519-2",
+            type=VerificationMethodType.JSON_WEB_KEY_2020,
+            verification_material=VerificationMaterial(
+                format=VerificationMaterialFormat.JWK,
+                value=json_dumps(
+                    {
+                        "kty": "OKP",
+                        "crv": "Ed25519",
+                        "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+                        "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
+                    }
+                ),
+            ),
+        ),
+        align_kid=True,
+    )
+
+    assert isinstance(key, OKPKey)
+    assert not key.public_only
+
+    assert key.as_dict(is_private=True) == {
+        "kty": "OKP",
+        "kid": "did:example:alice#key-ed25519-2",
+        "crv": "Ed25519",
+        "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+        "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
+    }
+
+
 def test_extract_ec_key_from_json_web_key_2020_verification_method():
     key = extract_key(
         VerificationMethod(
@@ -72,38 +104,6 @@ def test_extract_ec_key_from_json_web_key_2020_verification_method():
         "crv": "P-256",
         "x": "L0crjMN1g0Ih4sYAJ_nGoHUck2cloltUpUVQDhF2nHE",
         "y": "SxYgE7CmEJYi7IDhgK5jI4ZiajO8jPRZDldVhqFpYoo",
-    }
-
-
-def test_extract_okp_key_from_json_web_key_2020_secret():
-    key = extract_key(
-        Secret(
-            kid="did:example:alice#key-ed25519-2",
-            type=VerificationMethodType.JSON_WEB_KEY_2020,
-            verification_material=VerificationMaterial(
-                format=VerificationMaterialFormat.JWK,
-                value=json_dumps(
-                    {
-                        "kty": "OKP",
-                        "crv": "Ed25519",
-                        "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
-                        "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
-                    }
-                ),
-            ),
-        ),
-        align_kid=True,
-    )
-
-    assert isinstance(key, OKPKey)
-    assert not key.public_only
-
-    assert key.as_dict(is_private=True) == {
-        "kty": "OKP",
-        "kid": "did:example:alice#key-ed25519-2",
-        "crv": "Ed25519",
-        "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
-        "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
     }
 
 
@@ -166,6 +166,31 @@ def test_extract_key_from_x25519_key_agreement_key_2019_verification_method():
     }
 
 
+def test_extract_key_from_x25519_key_agreement_key_2019_secret():
+    key = extract_key(
+        Secret(
+            kid="did:example:eve#key-x25519-1",
+            type=VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2019,
+            verification_material=VerificationMaterial(
+                format=VerificationMaterialFormat.BASE58,
+                value="2b5J8uecvwAo9HUGge5NKQ7HoRNKUKCjZ7Fr4mDgWkwqFyjLPWt7rv5kL3UPeG3e4B9Sy4H2Q2zAuWcP2RNtgJ4t",
+            ),
+        ),
+        align_kid=True,
+    )
+
+    assert isinstance(key, OKPKey)
+    assert not key.public_only
+
+    assert key.as_dict(is_private=True) == {
+        "kty": "OKP",
+        "kid": "did:example:eve#key-x25519-1",
+        "crv": "X25519",
+        "x": "piw5XSMkceDeklaHQZXPBLQySyAwF8eZ-vddihdURS0",
+        "d": "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
+    }
+
+
 def test_extract_key_from_ed25519_verification_key_2018_verification_method():
     key = extract_key(
         VerificationMethod(
@@ -191,7 +216,32 @@ def test_extract_key_from_ed25519_verification_key_2018_verification_method():
     }
 
 
-def test_extract_key_from_x25519_key_agreement_key_2020_method_verification_method():
+def test_extract_key_from_ed25519_verification_key_2018_secret():
+    key = extract_key(
+        Secret(
+            kid="did:example:eve#key-ed25519-1",
+            type=VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+            verification_material=VerificationMaterial(
+                format=VerificationMaterialFormat.BASE58,
+                value="2b5J8uecvwAo9HUGge5NKQ7HoRNKUKCjZ7Fr4mDgWkwqATnLmZDx7Seu6NqTuFKkxuHNT27GcoxVZQCkWJhNvaUQ",
+            ),
+        ),
+        align_kid=True,
+    )
+
+    assert isinstance(key, OKPKey)
+    assert not key.public_only
+
+    assert key.as_dict(is_private=True) == {
+        "kty": "OKP",
+        "kid": "did:example:eve#key-ed25519-1",
+        "crv": "Ed25519",
+        "x": "VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE",
+        "d": "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
+    }
+
+
+def test_extract_key_from_x25519_key_agreement_key_2020_verification_method():
     key = extract_key(
         VerificationMethod(
             id="did:example:dave#key-x25519-2",
@@ -213,6 +263,31 @@ def test_extract_key_from_x25519_key_agreement_key_2020_method_verification_meth
         "kid": "did:example:dave#key-x25519-2",
         "crv": "X25519",
         "x": "BIiFcQEn3dfvB2pjlhOQQour6jXy9d5s2FKEJNTOJik",
+    }
+
+
+def test_extract_key_from_x25519_key_agreement_key_2020_secret():
+    key = extract_key(
+        Secret(
+            kid="did:example:eve#key-x25519-2",
+            type=VerificationMethodType.X25519_KEY_AGREEMENT_KEY_2020,
+            verification_material=VerificationMaterial(
+                format=VerificationMaterialFormat.MULTIBASE,
+                value="zshCmpUZKtFrAfudMf7NzD3oR6yhWe6i2434FDktk9CYZfkndn7suDrqnRWvrVDHk95Z7vBRJChFxTgBF9qzq7D3xPe",
+            ),
+        ),
+        align_kid=True,
+    )
+
+    assert isinstance(key, OKPKey)
+    assert not key.public_only
+
+    assert key.as_dict(is_private=True) == {
+        "kty": "OKP",
+        "kid": "did:example:eve#key-x25519-2",
+        "crv": "X25519",
+        "x": "piw5XSMkceDeklaHQZXPBLQySyAwF8eZ-vddihdURS0",
+        "d": "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
     }
 
 
@@ -238,4 +313,29 @@ def test_extract_key_from_ed25519_verification_key_2020_verification_method():
         "kid": "did:example:dave#key-ed25519-2",
         "crv": "Ed25519",
         "x": "owBhCbktDjkfS6PdQddT0D3yjSitaSysP3YimJ_YgmA",
+    }
+
+
+def test_extract_key_from_ed25519_verification_key_2020_secret():
+    key = extract_key(
+        Secret(
+            kid="did:example:eve#key-ed25519-2",
+            type=VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+            verification_material=VerificationMaterial(
+                format=VerificationMaterialFormat.MULTIBASE,
+                value="zrv2DyJwnoQWzS74nPkHHdM7NYH27BRNFBG9To7Fca9YzWhfBVa9Mek52H9bJexjdNqxML1F3TGCpjLNkCwwgQDvd5J",
+            ),
+        ),
+        align_kid=True,
+    )
+
+    assert isinstance(key, OKPKey)
+    assert not key.public_only
+
+    assert key.as_dict(is_private=True) == {
+        "kty": "OKP",
+        "kid": "did:example:eve#key-ed25519-2",
+        "crv": "Ed25519",
+        "x": "VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE",
+        "d": "T2azVap7CYD_kB8ilbnFYqwwYb5N-GcD6yjGEvquZXg",
     }

--- a/tests/unit/keys/test_extract_sign_alg.py
+++ b/tests/unit/keys/test_extract_sign_alg.py
@@ -1,0 +1,209 @@
+from authlib.common.encoding import json_dumps
+
+from didcomm.common.algorithms import SignAlg
+from didcomm.common.types import (
+    VerificationMethodType,
+    VerificationMaterial,
+    VerificationMaterialFormat,
+)
+from didcomm.core.utils import extract_sign_alg
+from didcomm.did_doc.did_doc import VerificationMethod
+from didcomm.secrets.secrets_resolver import Secret
+
+
+def test_extract_sign_alg_from_json_web_key_2020_verification_method_with_p256_key():
+    verification_method = VerificationMethod(
+        id="did:example:alice#key-2",
+        controller="did:example:alice#key-2",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "2syLh57B-dGpa0F8p1JrO6JU7UUSF6j7qL-vfk1eOoY",
+                    "y": "BgsGtI7UPsObMRjdElxLOrgAO9JggNMjOcfzEPox18w",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(verification_method)
+
+    assert sign_alg == SignAlg.ES256
+
+
+def test_extract_sign_alg_from_json_web_key_2020_secret_with_p256_key():
+    secret = Secret(
+        kid="did:example:alice#key-2",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "2syLh57B-dGpa0F8p1JrO6JU7UUSF6j7qL-vfk1eOoY",
+                    "y": "BgsGtI7UPsObMRjdElxLOrgAO9JggNMjOcfzEPox18w",
+                    "d": "7TCIdt1rhThFtWcEiLnk_COEjh1ZfQhM4bW2wz-dp4A",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(secret)
+
+    assert sign_alg == SignAlg.ES256
+
+
+def test_extract_sign_alg_from_json_web_key_2020_verification_method_with_secp256k1_key():
+    verification_method = VerificationMethod(
+        id="did:example:alice#key-3",
+        controller="did:example:alice#key-3",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "EC",
+                    "crv": "secp256k1",
+                    "x": "aToW5EaTq5mlAf8C5ECYDSkqsJycrW-e1SQ6_GJcAOk",
+                    "y": "JAGX94caA21WKreXwYUaOCYTBMrqaX4KWIlsQZTHWCk",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(verification_method)
+
+    assert sign_alg == SignAlg.ES256K
+
+
+def test_extract_sign_alg_from_json_web_key_2020_secret_with_secp256k1_key():
+    secret = Secret(
+        kid="did:example:alice#key-3",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "EC",
+                    "crv": "secp256k1",
+                    "x": "aToW5EaTq5mlAf8C5ECYDSkqsJycrW-e1SQ6_GJcAOk",
+                    "y": "JAGX94caA21WKreXwYUaOCYTBMrqaX4KWIlsQZTHWCk",
+                    "d": "N3Hm1LXA210YVGGsXw_GklMwcLu_bMgnzDese6YQIyA",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(secret)
+
+    assert sign_alg == SignAlg.ES256K
+
+
+def test_extract_sign_alg_from_json_web_key_2020_verification_method_with_ed25519_key():
+    verification_method = VerificationMethod(
+        id="did:example:alice#key-1",
+        controller="did:example:alice#key-1",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(verification_method)
+
+    assert sign_alg == SignAlg.ED25519
+
+
+def test_extract_sign_alg_from_json_web_key_2020_secret_with_ed25519_key():
+    secret = Secret(
+        kid="did:example:alice#key-1",
+        type=VerificationMethodType.JSON_WEB_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.JWK,
+            value=json_dumps(
+                {
+                    "kty": "OKP",
+                    "d": "pFRUKkyzx4kHdJtFSnlPA9WzqkDT1HWV0xZ5OYZd2SY",
+                    "crv": "Ed25519",
+                    "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww",
+                }
+            ),
+        ),
+    )
+
+    sign_alg = extract_sign_alg(secret)
+
+    assert sign_alg == SignAlg.ED25519
+
+
+def test_extract_sign_alg_from_ed25519_verification_key_2018_verification_method():
+    verification_method = VerificationMethod(
+        id="did:example:dave#key-ed25519-1",
+        controller="did:example:dave#key-ed25519-1",
+        type=VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.BASE58,
+            value="ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+        ),
+    )
+
+    sign_alg = extract_sign_alg(verification_method)
+
+    assert sign_alg == SignAlg.ED25519
+
+
+def test_extract_sign_alg_from_ed25519_verification_key_2018_secret():
+    secret = Secret(
+        kid="did:example:eve#key-ed25519-1",
+        type=VerificationMethodType.ED25519_VERIFICATION_KEY_2018,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.BASE58,
+            value="2b5J8uecvwAo9HUGge5NKQ7HoRNKUKCjZ7Fr4mDgWkwqATnLmZDx7Seu6NqTuFKkxuHNT27GcoxVZQCkWJhNvaUQ",
+        ),
+    )
+
+    sign_alg = extract_sign_alg(secret)
+
+    assert sign_alg == SignAlg.ED25519
+
+
+def test_extract_sign_alg_from_ed25519_verification_key_2020_verification_method():
+    verification_method = VerificationMethod(
+        id="did:example:dave#key-ed25519-2",
+        controller="did:example:dave#key-ed25519-2",
+        type=VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.MULTIBASE,
+            value="z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+        ),
+    )
+
+    sign_alg = extract_sign_alg(verification_method)
+
+    assert sign_alg == SignAlg.ED25519
+
+
+def test_extract_sign_alg_from_ed25519_verification_key_2020_secret():
+    secret = Secret(
+        kid="did:example:eve#key-ed25519-2",
+        type=VerificationMethodType.ED25519_VERIFICATION_KEY_2020,
+        verification_material=VerificationMaterial(
+            format=VerificationMaterialFormat.MULTIBASE,
+            value="zrv2DyJwnoQWzS74nPkHHdM7NYH27BRNFBG9To7Fca9YzWhfBVa9Mek52H9bJexjdNqxML1F3TGCpjLNkCwwgQDvd5J",
+        ),
+    )
+
+    sign_alg = extract_sign_alg(secret)
+
+    assert sign_alg == SignAlg.ED25519


### PR DESCRIPTION
- Added support for Base58 and Multibase (Base58 only) key formats for secrets and corresponding unit tests.
- Corrected extract_sign_alg function. Added unit tests for it.