### PR TITLE
fix: correct type of anoncrypt alg default

### DIFF
--- a/didcomm/core/defaults.py
+++ b/didcomm/core/defaults.py
@@ -2,4 +2,4 @@ from didcomm.common.algorithms import AnonCryptAlg, AuthCryptAlg
 
 
 DEF_ENC_ALG_AUTH: AuthCryptAlg = AuthCryptAlg.A256CBC_HS512_ECDH_1PU_A256KW
-DEF_ENC_ALG_ANON: AuthCryptAlg = AnonCryptAlg.XC20P_ECDH_ES_A256KW
+DEF_ENC_ALG_ANON: AnonCryptAlg = AnonCryptAlg.XC20P_ECDH_ES_A256KW


### PR DESCRIPTION
This fixes what appears to be a typo in the type of the DEF_ENC_ALG_ANON Type

Signed-off-by: Daniel Bluhm <dbluhm@pm.me>