### PR TITLE
Change `please-ack` and `ack` fields to list of strings

### DIFF
--- a/didcomm/message.py
+++ b/didcomm/message.py
@@ -163,9 +163,9 @@ class GenericMessage(Generic[T]):
             or self.expires_time is not None
             and not isinstance(self.expires_time, int)
             or self.please_ack is not None
-            and not isinstance(self.please_ack, bool)
+            and not isinstance(self.please_ack, List)
             or self.ack is not None
-            and not isinstance(self.ack, str)
+            and not isinstance(self.ack, List)
             or self.thid is not None
             and not isinstance(self.thid, str)
             or self.pthid is not None

--- a/tests/test_vectors/didcomm_messages/messages.py
+++ b/tests/test_vectors/didcomm_messages/messages.py
@@ -240,3 +240,9 @@ def attachment_multi_2_msg():
         ),
     ]
     return msg
+
+def ack_msg():
+    msg = copy.deepcopy(TEST_MESSAGE)
+    msg.please_ack = ["a_msg"]
+    msg.ack = ["another_msg"]
+    return msg

--- a/tests/test_vectors/didcomm_messages/messages.py
+++ b/tests/test_vectors/didcomm_messages/messages.py
@@ -241,6 +241,7 @@ def attachment_multi_2_msg():
     ]
     return msg
 
+
 def ack_msg():
     msg = copy.deepcopy(TEST_MESSAGE)
     msg.please_ack = ["a_msg"]

--- a/tests/test_vectors/didcomm_messages/tests/test_vectors_plaintext_positive.py
+++ b/tests/test_vectors/didcomm_messages/tests/test_vectors_plaintext_positive.py
@@ -111,3 +111,18 @@ TEST_PLAINTEXT_ATTACHMENT_MULTI_2 = json_dumps(
         ],
     }
 )
+
+TEST_PLAINTEXT_ACKS = json_dumps(
+    {
+        "id": "1234567890",
+        "typ": "application/didcomm-plain+json",
+        "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+        "from": "did:example:alice",
+        "to": ["did:example:bob"],
+        "please_ack": ["a_msg"],
+        "ack": ["another_msg"],
+        "created_time": 1516269022,
+        "expires_time": 1516385931,
+        "body": {"messagespecificattribute": "and its value"},
+    }
+)

--- a/tests/unit/pack_plaintext/test_pack_plaintext.py
+++ b/tests/unit/pack_plaintext/test_pack_plaintext.py
@@ -10,7 +10,7 @@ from tests.test_vectors.didcomm_messages.messages import (
     attachment_base64_msg,
     minimal_msg,
     attachment_multi_1_msg,
-    attachment_multi_2_msg,
+    attachment_multi_2_msg, ack_msg,
 )
 from tests.test_vectors.didcomm_messages.spec.spec_test_vectors_plaintext import (
     TEST_PLAINTEXT_DIDCOMM_MESSAGE_SIMPLE,
@@ -21,7 +21,7 @@ from tests.test_vectors.didcomm_messages.tests.test_vectors_plaintext_positive i
     TEST_PLAINTEXT_ATTACHMENT_JSON,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_1,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
-    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL,
+    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL, TEST_PLAINTEXT_ACKS,
 )
 
 
@@ -82,5 +82,13 @@ async def test_pack_attachments_multi2(resolvers_config_bob):
     await check_pack_plaintext(
         attachment_multi_2_msg(),
         TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
+        resolvers_config_bob,
+    )
+
+@pytest.mark.asyncio
+async def test_pack_acks(resolvers_config_bob):
+    await check_pack_plaintext(
+        ack_msg(),
+        TEST_PLAINTEXT_ACKS,
         resolvers_config_bob,
     )

--- a/tests/unit/pack_plaintext/test_pack_plaintext.py
+++ b/tests/unit/pack_plaintext/test_pack_plaintext.py
@@ -10,7 +10,8 @@ from tests.test_vectors.didcomm_messages.messages import (
     attachment_base64_msg,
     minimal_msg,
     attachment_multi_1_msg,
-    attachment_multi_2_msg, ack_msg,
+    attachment_multi_2_msg,
+    ack_msg,
 )
 from tests.test_vectors.didcomm_messages.spec.spec_test_vectors_plaintext import (
     TEST_PLAINTEXT_DIDCOMM_MESSAGE_SIMPLE,
@@ -21,7 +22,8 @@ from tests.test_vectors.didcomm_messages.tests.test_vectors_plaintext_positive i
     TEST_PLAINTEXT_ATTACHMENT_JSON,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_1,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
-    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL, TEST_PLAINTEXT_ACKS,
+    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL,
+    TEST_PLAINTEXT_ACKS,
 )
 
 
@@ -84,6 +86,7 @@ async def test_pack_attachments_multi2(resolvers_config_bob):
         TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
         resolvers_config_bob,
     )
+
 
 @pytest.mark.asyncio
 async def test_pack_acks(resolvers_config_bob):

--- a/tests/unit/unpack/test_unpack_plaintext.py
+++ b/tests/unit/unpack/test_unpack_plaintext.py
@@ -8,7 +8,8 @@ from tests.test_vectors.didcomm_messages.messages import (
     attachment_links_msg,
     attachment_json_msg,
     attachment_multi_1_msg,
-    attachment_multi_2_msg, ack_msg,
+    attachment_multi_2_msg,
+    ack_msg,
 )
 from tests.test_vectors.didcomm_messages.spec.spec_test_vectors_plaintext import (
     TEST_PLAINTEXT_DIDCOMM_MESSAGE_SIMPLE,
@@ -20,7 +21,8 @@ from tests.test_vectors.didcomm_messages.tests.test_vectors_plaintext_positive i
     TEST_PLAINTEXT_ATTACHMENT_JSON,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_1,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
-    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL, TEST_PLAINTEXT_ACKS,
+    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL,
+    TEST_PLAINTEXT_ACKS,
 )
 
 
@@ -80,10 +82,9 @@ async def test_unpack_attachments_multi_2(resolvers_config_bob):
     assert unpack_result.metadata == PLAINTEXT_EXPECTED_METADATA
     assert unpack_result.message == attachment_multi_2_msg()
 
+
 @pytest.mark.asyncio
 async def test_unpack_ack(resolvers_config_bob):
-    unpack_result = await unpack(
-        resolvers_config_bob, TEST_PLAINTEXT_ACKS
-    )
+    unpack_result = await unpack(resolvers_config_bob, TEST_PLAINTEXT_ACKS)
     assert unpack_result.metadata == PLAINTEXT_EXPECTED_METADATA
     assert unpack_result.message == ack_msg()

--- a/tests/unit/unpack/test_unpack_plaintext.py
+++ b/tests/unit/unpack/test_unpack_plaintext.py
@@ -8,7 +8,7 @@ from tests.test_vectors.didcomm_messages.messages import (
     attachment_links_msg,
     attachment_json_msg,
     attachment_multi_1_msg,
-    attachment_multi_2_msg,
+    attachment_multi_2_msg, ack_msg,
 )
 from tests.test_vectors.didcomm_messages.spec.spec_test_vectors_plaintext import (
     TEST_PLAINTEXT_DIDCOMM_MESSAGE_SIMPLE,
@@ -20,7 +20,7 @@ from tests.test_vectors.didcomm_messages.tests.test_vectors_plaintext_positive i
     TEST_PLAINTEXT_ATTACHMENT_JSON,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_1,
     TEST_PLAINTEXT_ATTACHMENT_MULTI_2,
-    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL,
+    TEST_PLAINTEXT_DIDCOMM_MESSAGE_MINIMAL, TEST_PLAINTEXT_ACKS,
 )
 
 
@@ -79,3 +79,11 @@ async def test_unpack_attachments_multi_2(resolvers_config_bob):
     )
     assert unpack_result.metadata == PLAINTEXT_EXPECTED_METADATA
     assert unpack_result.message == attachment_multi_2_msg()
+
+@pytest.mark.asyncio
+async def test_unpack_ack(resolvers_config_bob):
+    unpack_result = await unpack(
+        resolvers_config_bob, TEST_PLAINTEXT_ACKS
+    )
+    assert unpack_result.metadata == PLAINTEXT_EXPECTED_METADATA
+    assert unpack_result.message == ack_msg()


### PR DESCRIPTION
Current types don't align with standard (see [here](https://identity.foundation/didcomm-messaging/spec/#acks)).

Fixes #78.