### PR TITLE
Fix python3.11-windows CI pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -108,7 +108,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
 
       - name: Install dependencies
         if: steps.setup.outputs.cache-hit != 'true'


### PR DESCRIPTION
Caching poetry deps seem to make the python 3.11 windows CI pipeline fail, so let's disable it for now. Also, the running time of the pipeline doesn't change much, so caching is not crucial.